### PR TITLE
Display platform info

### DIFF
--- a/assets/js/protos.js
+++ b/assets/js/protos.js
@@ -24,6 +24,35 @@ CommandSenderData.Type = {
     }
 };
 
+// PlatformData ========================================
+
+var PlatformData = self.PlatformData = {};
+
+PlatformData.read = function (pbf, end) {
+    return pbf.readFields(PlatformData._readField, {type: 0, name: "", version: "", minecraftVersion: ""}, end);
+};
+PlatformData._readField = function (tag, obj, pbf) {
+    if (tag === 1) obj.type = pbf.readVarint();
+    else if (tag === 2) obj.name = pbf.readString();
+    else if (tag === 3) obj.version = pbf.readString();
+    else if (tag === 4) obj.minecraftVersion = pbf.readString();
+};
+
+PlatformData.Type = {
+    "SERVER": {
+        "value": 0,
+        "options": {}
+    },
+    "CLIENT": {
+        "value": 1,
+        "options": {}
+    },
+    "PROXY": {
+        "value": 2,
+        "options": {}
+    }
+};
+
 // HeapData ========================================
 
 var HeapData = self.HeapData = {};
@@ -41,10 +70,11 @@ HeapData._readField = function (tag, obj, pbf) {
 var HeapMetadata = self.HeapMetadata = {};
 
 HeapMetadata.read = function (pbf, end) {
-    return pbf.readFields(HeapMetadata._readField, {user: null}, end);
+    return pbf.readFields(HeapMetadata._readField, {user: null, platform: null}, end);
 };
 HeapMetadata._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.user = CommandSenderData.read(pbf, pbf.readVarint() + pbf.pos);
+    else if (tag === 2) obj.platform = PlatformData.read(pbf, pbf.readVarint() + pbf.pos);
 };
 
 // HeapEntry ========================================
@@ -78,7 +108,7 @@ SamplerData._readField = function (tag, obj, pbf) {
 var SamplerMetadata = self.SamplerMetadata = {};
 
 SamplerMetadata.read = function (pbf, end) {
-    return pbf.readFields(SamplerMetadata._readField, {user: null, startTime: 0, interval: 0, threadDumper: null, dataAggregator: null, comment: ""}, end);
+    return pbf.readFields(SamplerMetadata._readField, {user: null, startTime: 0, interval: 0, threadDumper: null, dataAggregator: null, comment: "", platform: null}, end);
 };
 SamplerMetadata._readField = function (tag, obj, pbf) {
     if (tag === 1) obj.user = CommandSenderData.read(pbf, pbf.readVarint() + pbf.pos);
@@ -87,6 +117,7 @@ SamplerMetadata._readField = function (tag, obj, pbf) {
     else if (tag === 4) obj.threadDumper = SamplerMetadata.ThreadDumper.read(pbf, pbf.readVarint() + pbf.pos);
     else if (tag === 5) obj.dataAggregator = SamplerMetadata.DataAggregator.read(pbf, pbf.readVarint() + pbf.pos);
     else if (tag === 6) obj.comment = pbf.readString();
+    else if (tag === 7) obj.platform = PlatformData.read(pbf, pbf.readVarint() + pbf.pos);
 };
 
 // SamplerMetadata.ThreadDumper ========================================

--- a/assets/js/types/sampler.js
+++ b/assets/js/types/sampler.js
@@ -103,10 +103,13 @@ function renderData(data, renderingFunction) {
         titleLines.push(title);
     }
 
-    if (titleLines.length > 0) {
-        let inner = titleLines.join("<br />");
+    if (titleLines.length > 1) {
+        let inner = "<details><summary>" + titleLines[0] + "</summary>" + titleLines.slice(1).join("<br />") + "</details>";
 
         $description.html(inner);
+        $description.show();
+    } else if (titleLines.length == 1) {
+        $description.html(titleLines[0]);
         $description.show();
     }
 }

--- a/assets/js/types/sampler.js
+++ b/assets/js/types/sampler.js
@@ -65,6 +65,8 @@ function renderData(data, renderingFunction) {
     $sampler.show();
 
     // display title
+    let titleLines = [];
+
     if (data["metadata"] && data["metadata"]["user"] && data["metadata"]["startTime"] && data["metadata"]["interval"]) {
         const user = data["metadata"]["user"];
         const start = new Date(data["metadata"]["startTime"]);
@@ -87,7 +89,24 @@ function renderData(data, renderingFunction) {
             title = 'Profile' + comment + ' created by <img src="https://minotar.net/avatar/Console/20.png" alt=""> ' + name + ' at ' + startTime + ' on ' + startDate + ', interval=' + interval + 'ms';
         }
 
-        $description.html(title);
+        titleLines.push(title);
+    }
+
+    if (data["metadata"] && data["metadata"]["platform"]) {
+        const platform = data["metadata"]["platform"];
+        const platformType = Object.keys(PlatformData.Type)[platform.type].toLowerCase();
+        let title = platform.name + ' version "' + platform.version + '" (' + platformType + ')';
+        if (platform["minecraftVersion"]) {
+            title = title + ', Minecraft ' + platform.minecraftVersion;
+        }
+
+        titleLines.push(title);
+    }
+
+    if (titleLines.length > 0) {
+        let inner = titleLines.join("<br />");
+
+        $description.html(inner);
         $description.show();
     }
 }

--- a/proto/spark.proto
+++ b/proto/spark.proto
@@ -13,6 +13,19 @@ message CommandSenderData {
   }
 }
 
+message PlatformData {
+  Type type = 1;
+  string name = 2;
+  string version = 3;
+  string minecraftVersion = 4; // optional
+
+  enum Type {
+    SERVER = 0;
+    CLIENT = 1;
+    PROXY = 2;
+  }
+}
+
 message HeapData {
   HeapMetadata metadata = 1;
   repeated HeapEntry entries = 2;
@@ -20,6 +33,7 @@ message HeapData {
 
 message HeapMetadata {
   CommandSenderData user = 1;
+  PlatformData platform = 2;
 }
 
 message HeapEntry {
@@ -41,6 +55,7 @@ message SamplerMetadata {
   ThreadDumper threadDumper = 4;
   DataAggregator dataAggregator = 5;
   string comment = 6;
+  PlatformData platform = 7;
 
   message ThreadDumper {
     Type type = 1;


### PR DESCRIPTION
This is the spark-web counterpart to lucko/spark#58.

Things to consider:
- How are we going to display this data? We could add it as an extra line under the user details, or we could replace that an expandable panel.
- The heap summary data includes sender data but doesn't appear to use it. Should we add sender and platform data to the heap summary page?