### PR TITLE
Add method names for yarn mappings in sampler

### DIFF
--- a/assets/js/types/sampler.js
+++ b/assets/js/types/sampler.js
@@ -379,7 +379,7 @@ function doYarnRemapping(node, yarnMappings) {
         originalClassName = className;
         className = yarnClassName;
     }
-    if (yarnMethodName && typeof(yarnMethodName) !== "string") {
+    if (yarnMethodName && typeof(yarnMethodName) === "string") {
         originalMethodName = methodName;
         methodName = yarnMethodName;
     }


### PR DESCRIPTION
Hello, this typo prevented yarn method names from showing!